### PR TITLE
Assign Offsets to Messages on Creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "2.4.3"
-	id("io.spring.dependency-management") version "1.0.11.RELEASE"
-	kotlin("jvm") version "1.4.30"
-	kotlin("plugin.spring") version "1.4.30"
+    id("org.springframework.boot") version "2.4.3"
+    id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    kotlin("jvm") version "1.4.30"
+    kotlin("plugin.spring") version "1.4.30"
 }
 
 group = "com.example"
@@ -12,27 +12,28 @@ version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.+")
-	developmentOnly("org.springframework.boot:spring-boot-devtools")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.+")
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.awaitility:awaitility-kotlin:4.0.3")
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "11"
-	}
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "11"
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/com/example/kafka/controller/MessageController.kt
+++ b/src/main/kotlin/com/example/kafka/controller/MessageController.kt
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
-
 @RestController
 @RequestMapping("/messages")
 class MessageController(
@@ -42,7 +41,6 @@ class MessageController(
                 offset = nextOffset
             )
         )
-
 
         return ResponseEntity(
             MessageModel(

--- a/src/main/kotlin/com/example/kafka/controller/MessageController.kt
+++ b/src/main/kotlin/com/example/kafka/controller/MessageController.kt
@@ -8,18 +8,24 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
+
 @RestController
 @RequestMapping("/messages")
 class MessageController(
     private val messageRepository: MessageRepository
 ) {
 
+    companion object {
+        var offset = 0L
+    }
+
     @GetMapping
     fun getAllMessages(): ResponseEntity<List<MessageModel>> {
         val messages = messageRepository.findAll().map {
             MessageModel(
                 id = it.id,
-                data = it.data
+                data = it.data,
+                offset = it.offset
             )
         }
 
@@ -28,18 +34,30 @@ class MessageController(
 
     @PostMapping
     fun createMessage(@RequestBody request: CreateMessageRequest): ResponseEntity<MessageModel> {
+        val nextOffset = allocateOffset()
+
         val mongoMessage = messageRepository.save(
             MongoMessage(
-                data = request.data
+                data = request.data,
+                offset = nextOffset
             )
         )
+
 
         return ResponseEntity(
             MessageModel(
                 id = mongoMessage.id,
-                data = mongoMessage.data
+                data = mongoMessage.data,
+                offset = mongoMessage.offset
             ), HttpStatus.CREATED
         )
     }
 
+    @Synchronized
+    private fun allocateOffset(): Long {
+        val nextOffset = offset
+        offset++
+
+        return nextOffset
+    }
 }

--- a/src/main/kotlin/com/example/kafka/model/MessageModel.kt
+++ b/src/main/kotlin/com/example/kafka/model/MessageModel.kt
@@ -4,5 +4,6 @@ import org.bson.types.ObjectId
 
 class MessageModel (
     val id: ObjectId,
-    val data: String
+    val data: String,
+    val offset: Long
 )

--- a/src/main/kotlin/com/example/kafka/mongo/MongoMessage.kt
+++ b/src/main/kotlin/com/example/kafka/mongo/MongoMessage.kt
@@ -10,6 +10,8 @@ data class MongoMessage(
     @Id
     val id: ObjectId = ObjectId(),
 
-    val data: String = ""
+    val data: String = "",
+
+    val offset: Long = 0
 
 )

--- a/src/test/kotlin/com/example/kafka/CreateMessageIntegration.kt
+++ b/src/test/kotlin/com/example/kafka/CreateMessageIntegration.kt
@@ -5,6 +5,7 @@ import com.example.kafka.model.MessageModel
 import com.example.kafka.repository.MessageRepository
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.type.CollectionType
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -80,11 +81,10 @@ class CreateMessageIntegration @Autowired constructor(
         assertNotNull(response.body)
         assertEquals(count, response.body?.size)
 
-        val offsets = response.body?.map{it.offset}!!.sorted()
+        val actualOffsetsSorted = response.body?.map { it.offset }!!.sorted()
+        val expectedOffsets = (0 until 50).map { it.toLong() }
 
-        for (i in 0 until count) {
-            assertEquals(i.toLong(), offsets[i])
-        }
+        assertThat(actualOffsetsSorted).isEqualTo(expectedOffsets)
     }
 
     private fun sendCreateMessageRequest(body: CreateMessageRequest) {


### PR DESCRIPTION
## Description

Given that `n` messages are created asynchronously, each message should get an offset - starting from 0 to n - 1.
No offset should repeat itself twice.

**Note:**
There is currently only one topic, so the offsets are stored statically.
In the next PR, support for multiple topics would be added, and the offset will be persisted for each topic in a TopicRepository.